### PR TITLE
Figure out when the window is in the foreground

### DIFF
--- a/lib/foreground-window.js
+++ b/lib/foreground-window.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const windows = require("sdk/windows").browserWindows;
+
+// set a starting value
+let _foreground = windows.activeWindow;
+
+exports.isForeground = function (sdkWindow) {
+  return sdkWindow === _foreground;
+}
+
+exports.getForeground = function () {
+  return _foreground;
+}
+
+let basicWindowEvents = function() {
+  ['open','close','activate','deactivate'].forEach(function(k){
+    windows.on(k,function(window){
+      if (['activate'].indexOf(k) > -1) {
+        _foreground = window;
+     } else {
+        if (k === 'deactivate' || (windows.activeWindow === null)) {
+          _foreground = null;
+        }
+      }
+    })
+  });
+}();

--- a/lib/hot-tabs.js
+++ b/lib/hot-tabs.js
@@ -6,6 +6,7 @@ const { EventMethods, assert, bind, setHandlers, decodeQuery, copyMethods } = re
 const { winIdFromTab, getOuterId } =  require("tracking-utils");
 const { getFavicon } = require("sdk/places/favicon");
 const { all, defer } = require('sdk/core/promise');
+const { isForeground } = require("foreground-window");
 
 var viewerScript = data.load("mirror/viewer.js");
 
@@ -169,7 +170,9 @@ exports.TabSet = Class({
     if (reactivate) {
       reactivate.activate();
     }
-  }
+  },
+
+  get foreground() isForeground(this.sdkWindow)
 
 });
 

--- a/test/foreground-window-addon/foreground-window.js
+++ b/test/foreground-window-addon/foreground-window.js
@@ -1,0 +1,1 @@
+../../lib/foreground-window.js

--- a/test/foreground-window-addon/main.js
+++ b/test/foreground-window-addon/main.js
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+/*jshint forin:true, noarg:false, noempty:true, eqeqeq:true, bitwise:true,
+  strict:true, undef:true, curly:false, browser:true,
+  unused:true,
+  indent:2, maxerr:50, devel:true, node:true, boss:true, white:true,
+  globalstrict:true, nomen:false, newcap:true, moz: true */
+
+/*global */
+
+const promises = require("sdk/core/promise");
+const { defer, resolve } = require("sdk/core/promise");
+const timers = require("sdk/timers");
+
+const windows = require("sdk/windows").browserWindows;
+let { isForeground, getForeground } = require("foreground-window");
+
+/**
+  */
+let wait = function (ms) {
+  let { promise, resolve } = defer();
+  timers.setTimeout(resolve, ms);
+  return promise;
+};
+
+let waitasec = function(){
+  let { promise, resolve } = defer();
+  return wait(1000).then(resolve);
+};
+
+
+let chain = function () {
+  let p = promises.resolve(true);
+  for (let arg of Array.prototype.slice.call(arguments, 0)) {
+    if (typeof arg !== "function"){
+      throw new Error("arg not a function, and can't be in promise chain:" + arg)
+    }
+    p = p.then(arg);
+  }
+  return p;
+};
+/*
+exports["test chain works"] = function (assert, done) {
+  let starttime = Date.now();
+  chain(
+    function () console.log("starting"),
+    function () console.log('time:'),
+    waitasec,
+    waitasec,
+    function () {
+      let t = Date.now();
+      assert.ok((t - starttime) > 2000, 'chaining works!')
+    },
+    done
+  );
+};
+
+
+exports["test chain throws with any non functions"] = function (assert) {
+  assert.throws(function() {
+    chain(1);
+  }, "chain throws with any non functions!");
+};
+*/
+
+exports["test foreground.window window"] = function (assert, done) {
+
+  let orig = windows.activeWindow;
+  windows.activeWindow.activate();
+  assert.ok(isForeground(windows.activeWindow),"active window is foreground.window");
+
+  let current = windows.open({
+    url: "about:addons",
+    onOpen: function(window) {
+        waitasec().then(function(){
+        assert.ok(windows.activeWindow === window,"1, window is activeWindow");
+        assert.ok(isForeground(windows.activeWindow),"3, active is new window");
+        assert.ok(!isForeground(orig),"4, active is not old window");
+        assert.ok(isForeground(window),"5, this window is active");
+        assert.equal(getForeground(),window,"6, getForeground ok");
+        wait(1000).then(done);
+      })
+    }
+  });
+
+};
+
+require("sdk/test/runner").runTestsFromModule(module);

--- a/test/foreground-window-addon/package.json
+++ b/test/foreground-window-addon/package.json
@@ -1,0 +1,1 @@
+{ "id": "foreground-window-test"}


### PR DESCRIPTION
`windows.activeWindow` only tells you if some other Firefox window is in the foreground, not if Firefox itself is entirely in the background.  I'd like to know when we're in the foreground.

Would help with #88 and notification in general.

We might be able to tell this from tracking the window inactive event.
