### PR TITLE
update user presence on a shared tab

### DIFF
--- a/data/xulstyles/hotdish.css
+++ b/data/xulstyles/hotdish.css
@@ -38,44 +38,55 @@
 .hotdish sidebarheader .tabs-closebutton {}
 
 
+
 /* this isn't working old firefoxes!  */
 .hotdish #hotdish-widget,
 .hotdish #hotdish-button,
 .hotdish #australis-hotdish-button {
-	//background: -moz-radial-gradient(center, circle, rgba(255,255,255,1) 0%, rgba(255,155,0,1) 100%);
+	/*background: -moz-radial-gradient(center, circle, rgba(255,255,255,1) 0%, rgba(255,155,0,1) 100%);*/
 }
 
 .hotdish #hotdish-button .toolbarbutton-icon,
 .hotdish #australis-hotdish-button .toolbarbutton-icon {
 	-moz-appearence: none !important;
-	//background: -moz-radial-gradient(center, circle, rgba(255,255,255,1) 0%, rgba(255,155,0,1) 100%);
+	/*background: -moz-radial-gradient(center, circle, rgba(255,255,255,1) 0%, rgba(255,155,0,1) 100%);*/
 }
-
-
-
-
-
-
-
-
 
 
 /*Presenter tab style*/
-.hotdish #presenter-tab tab.tabbrowser-tab {
-  border-top: 1px solid #2ecc71;
+.hotdish tab.tabbrowser-tab[hotdish=presenting] .tab-background-start,
+.hotdish tab.tabbrowser-tab[hotdish=presenting] .tab-background-middle,
+.hotdish tab.tabbrowser-tab[hotdish=presenting] .tab-background-end
+{
+  background-color: #2ecc71 !important;
+}
+
+/*Live tab style*/
+.hotdish tab.tabbrowser-tab[hotdish=live] .tab-background-start,
+.hotdish tab.tabbrowser-tab[hotdish=live] .tab-background-middle,
+.hotdish tab.tabbrowser-tab[hotdish=live] .tab-background-end
+{
+    background-color: 2px solid #3498db !important!;
+}
+
+/*Viewing tab style*/
+.hotdish tab.tabbrowser-tab[hotdish=viewing] .tab-background-start,
+.hotdish tab.tabbrowser-tab[hotdish=viewing] .tab-background-middle,
+.hotdish tab.tabbrowser-tab[hotdish=viewing] .tab-background-end
+{
+    background-color: red !important;
 }
 
 
-/*Spectator tab style*/
-.hotdish #spectator-tab {
-    border-top: 1px solid #3498db;
+/*Normal tab style*/
+.hotdish tab.tabbrowser-tab[hotdish=normal] .tab-background-start,
+.hotdish tab.tabbrowser-tab[hotdish=normal] .tab-background-middle,
+.hotdish tab.tabbrowser-tab[hotdish=normal] .tab-background-end
+{
+    background-color: inherit !important;
 }
 
 
-/*Shared tab style*/
-.hotdish #shared-tab {
-
-}
 
 
 

--- a/lib/group.js
+++ b/lib/group.js
@@ -135,6 +135,7 @@ exports.Group = Class({
       this.sidebar.port.emit("setCurrentTabState", tab.state());
     }).bind(this));
     this.tabSet.on("stateChange", (function (tab) {
+      tab.xulTab.setAttribute("hotdish",tab.state());
       if (tab.isActive()) {
         this.sidebar.port.emit("setCurrentTabState", tab.state());
       }

--- a/lib/hot-tabs.js
+++ b/lib/hot-tabs.js
@@ -8,6 +8,8 @@ const { getFavicon } = require("sdk/places/favicon");
 const { all, defer } = require('sdk/core/promise');
 const { isForeground } = require("foreground-window");
 const { setTimeout } = require("sdk/timers");
+const { getTabs, getTabId } = require("sdk/tabs/utils");
+
 
 var viewerScript = data.load("mirror/viewer.js");
 var togetherJsCss = data.load("togetherjs-overrides.css");
@@ -64,6 +66,7 @@ exports.TabSet = Class({
   initialize: function (group, domWindow, sdkWindow) {
     activate();
     this.group = group;
+    this.domWindow = domWindow;
     this.windowId = getOuterId(domWindow);
     this.sdkWindow = sdkWindow;
     assert(! allTabSets[this.windowId], "Recreating TabSet with a new window");
@@ -93,6 +96,7 @@ exports.TabSet = Class({
       this._tabsById[id].destroy();
     }
     this.sdkWindow = null;
+    this.domWindow = null;
     delete allTabSets[this.windowId];
   },
 
@@ -245,6 +249,14 @@ exports.Tab = Class({
 
   initialize: function (tabSet, sdkTab) {
     bind(this, "createWorker _checkTitle");
+
+    let alltabs = getTabs(tabSet.domWindow);
+    for (let t in alltabs){
+      if (getTabId(alltabs[t]) === sdkTab.id) {
+        this.xulTab = alltabs[t];
+      }
+    }
+    assert(this.xulTab); // must exist, should be a <tab.tabbrowser-tabs>
     this.sdkTab = sdkTab;
     this.tabSet = tabSet;
     this.id = this.tabSet.group.clientId + "_" + this.sdkTab.id;


### PR DESCRIPTION
When you are Presenting a Tab:
- there should be a Growl notification "You are presenting this tab to [user]"
- the browser tab should have a Presenting icon, color (green?) and maybe avatars of the people on the page are in the tab.
- the content window should have a light green outline too?

When you are Spectating on a Tab:
- there should be a Growl notification "You spectating on this tab by [user]"
- the browser tab should have a Spectating icon, color (blue?) and maybe avatars of the people on the page are in the tab.
- the content window should have a light blue outline too?

When are on a Shared Tab with another user:
- there should be a Growl notification "You are live-sharing on this tab with [user]"
- the browser tab should have a Share icon, color (?) and maybe avatars of the people on the page are in the tab.

When a user joins your tab you are Presenting on:
- there should be a Growl notification "[user] is spectating on your page."
- the browser tab should have a Presenting icon, color (green?) and maybe avatars of the people on the page are in the tab.
- the content window should have a light green outline too?

When a user joins a tab you are Spectating on:
- there should be a Growl notification "[user] is now spectating on this page too."
- the browser tab should have a Spectating icon, color (blue?) and maybe avatars of the people on the page are in the tab.
- the content window should have a light blue outline too?

When a user joins a page you are Sharing on:
- there should be a Growl notification "[user] has joined this page with you."
- the browser tab should have a Share icon, color (?) and maybe avatars of the people on the page are in the tab.
